### PR TITLE
Fix action branch rules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy
-on: [push]
+
+on:
+  push:
+    branches: [develop]
 
 jobs:
   build:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore: [develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 jobs:
   build:
@@ -21,5 +21,5 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: main
+          DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Lint should run on PRs using `develop` and deployments shouldn't happen on pull requests but only when pushing to `develop`.