### PR TITLE
Resolve relative link resolution issue

### DIFF
--- a/BishopClassicMotors.csproj
+++ b/BishopClassicMotors.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.36" />
+    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.44" />
   </ItemGroup>
 
   <ItemGroup>

--- a/input/Work.cshtml
+++ b/input/Work.cshtml
@@ -3,7 +3,7 @@ Title: "Work"
 <h1>@Document.GetTitle()</h1>
 <p>Our team has completed hundreds of projects over decades. A few of our most recent:</p>
 <ul>
-    @foreach (IDocument post in Outputs.FilterSources("work/*").OrderBy(p => p.GetString(Constants.VehicleId)))
+    @foreach (IDocument post in Outputs.FromPipeline("Content").FilterSources("work/*").OrderBy(p => p.GetString(Constants.VehicleId)))
     {
         <li>@Html.DocumentLink(post)</li>
     }


### PR DESCRIPTION
Use an explicit pipeline reference to avoid relative link resolution issues. Also bumps `Statiq.Web` to the latest.